### PR TITLE
UI parameters

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -22,11 +22,11 @@ OverdriveAudioProcessorEditor::OverdriveAudioProcessorEditor (OverdriveAudioProc
     pedalLabel.setFont(juce::FontOptions(30.0f));
     pedalLabel.setText(pedalName, juce::dontSendNotification);
     
-    addAndMakeVisible(pedalLabel);
     addAndMakeVisible(powerSwitch);
     addAndMakeVisible(pregainDial);
-    addAndMakeVisible(filterDial);
     addAndMakeVisible(volumeDial);
+    addAndMakeVisible(filterDial);
+    addAndMakeVisible(pedalLabel);
 }
 
 OverdriveAudioProcessorEditor::~OverdriveAudioProcessorEditor()
@@ -62,7 +62,7 @@ void OverdriveAudioProcessorEditor::resized()
     int powerSwitchX = centerWithHorizontal(powerSwitchWidth);
     int powerSwitchY = getHeight() * 2.0f/3;
     powerSwitch.setBounds(powerSwitchX, powerSwitchY, powerSwitchWidth, powerSwitchHeight);
-    
+
     int labelWidth = getWidth();
     int labelHeight = powerSwitch.getY() - filterDial.getBottom();
     int labelX = centerWithHorizontal(labelWidth);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -219,8 +219,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout OverdriveAudioProcessor::cre
     std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
     
     const float minPregain = 1.0f;
-    const float maxPregain = 2.0f;
-    const float defaultPregain = 0.8f;
+    const float maxPregain = 30.0f;
+    const float defaultPregain = 5.0f;
     
     const float minFreq = 70.0f;
     const float maxFreq = 10000.0f;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -295,7 +295,6 @@ bool OverdriveAudioProcessor::hasEditor() const
 juce::AudioProcessorEditor* OverdriveAudioProcessor::createEditor()
 {
     return new OverdriveAudioProcessorEditor (*this);
-//    return new juce::GenericAudioProcessorEditor (*this);
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -61,7 +61,7 @@ private:
     bool powerOn = false;
     void updatePowerOn();
     
-    float pregain  = 1.0f;
+    juce::dsp::Gain<float> pregain;
     void updatePregain();
     
     const float highPassCutoff = 70.0f;
@@ -71,11 +71,12 @@ private:
     Filter lowPassFilter;
     void updateLowPassFilter();
     
-    float volume = 1.0f;
+    juce::dsp::Gain<float> volume;
     void updateVolume();
     
-    // anti-aliasing
-    juce::dsp::ProcessorDuplicator<juce::dsp::FIR::Filter<float>, juce::dsp::FIR::Coefficients<float>> antiAliasingFilter;
+    using Filter = juce::dsp::FIR::Filter<float>;
+    using Coefficients = juce::dsp::FIR::Coefficients<float>;
+    juce::dsp::ProcessorDuplicator<Filter, Coefficients> antiAliasingFilter;
     
     float udoDistortion(float input);
     

--- a/Source/UI/Dial.cpp
+++ b/Source/UI/Dial.cpp
@@ -42,8 +42,6 @@ void Dial::initLabel(const juce::String parameterName){
 
 void Dial::paint (juce::Graphics& g)
 {
-    g.setColour(juce::Colours::white);
-    g.drawRect(0, 0, getWidth(), getHeight());
 }
 
 void Dial::resized()

--- a/Source/UI/Dial.cpp
+++ b/Source/UI/Dial.cpp
@@ -15,9 +15,9 @@
 Dial::Dial(juce::AudioProcessorValueTreeState& treeState, juce::String parameterId, juce::String parameterName)
 {
     initSlider(treeState, parameterId);
-//    slider.setLookAndFeel(&dialStyle);
+    slider.setLookAndFeel(&dialStyle);
     addAndMakeVisible(slider);
-    
+
     initLabel(parameterName);
     addAndMakeVisible(label);
 }
@@ -42,6 +42,8 @@ void Dial::initLabel(const juce::String parameterName){
 
 void Dial::paint (juce::Graphics& g)
 {
+    g.setColour(juce::Colours::white);
+    g.drawRect(0, 0, getWidth(), getHeight());
 }
 
 void Dial::resized()
@@ -58,4 +60,10 @@ void Dial::resized()
 
     slider.setBounds(sliderXPos, sliderYPos, sliderWidth, sliderHeight);
     label.setBounds(labelXPos, labelYPos, labelWidth, labelHeight);
+}
+
+bool Dial::hitTest(int x, int y) {
+    bool withinSliderHorizontal = slider.getX() <= x && x <= slider.getRight();
+    bool withinSliderVertical = slider.getY() <= y && y <= slider.getBottom();
+    return withinSliderHorizontal && withinSliderVertical;
 }

--- a/Source/UI/Dial.h
+++ b/Source/UI/Dial.h
@@ -48,6 +48,8 @@ public:
 
     void paint (juce::Graphics&) override;
     void resized() override;
+    
+    bool hitTest(int x, int y) override;
 
 private:
     DialLookAndFeel dialStyle;


### PR DESCRIPTION
Fixed overlapping dial component bug 
- affected mouse engagement when turning dials that were trapped underneath another dial
- solution: override hitTest() to return true only if interacting with slider itself